### PR TITLE
Fixed compilation in Visual Studio

### DIFF
--- a/src/ofxVectorField.cpp
+++ b/src/ofxVectorField.cpp
@@ -167,7 +167,7 @@ void ofxVectorField::setFromImage(ofImage & image){
 	
 	// storage for brightness
 	unsigned char * imagePixels = image.getPixels().getData();
-	unsigned char brightness[imgPixelCount];
+	unsigned char* brightness = new unsigned char[imgPixelCount];
 	
 	if( image.getPixels().getImageType() == OF_IMAGE_GRAYSCALE){
 		
@@ -186,7 +186,7 @@ void ofxVectorField::setFromImage(ofImage & image){
 		
 		// convert RGB to luma
 		unsigned char * imagePixels = image.getPixels().getData();
-		unsigned char brightness[imgPixelCount];
+		unsigned char* brightness = new unsigned char[imgPixelCount];
 		int bpp = image.getPixels().getBytesPerPixel();
 		
 		for(int x=0; x<imgW; x++){


### PR DESCRIPTION
There were compilation errors, due to dynamic size being given to a stack-allocated array. 
You can see it here - https://i.imgur.com/AksEzMv.png .
Some compilers allow you to do it, some don't.
As far as I examined, this does not cause any problems